### PR TITLE
Add chat rooms, list of chats and transactions via chats

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,7 +25,7 @@ exports.createTransaction = functions.region('asia-southeast1').https.onCall(asy
   const receiverId = req.receiverId;
   const itemId = req.itemId;
 
-  if (receiverId != context.auth?.uid) {
+  if (receiverId != context.auth?.uid && giverId != context.auth?.uid) {
     throw new HttpsError('unauthenticated', "Unauthorised");
   }
 

--- a/lib/Components/ItemBottomNavigationBar.dart
+++ b/lib/Components/ItemBottomNavigationBar.dart
@@ -8,13 +8,17 @@ class ItemBottomNavigationBar extends StatelessWidget {
   final VoidCallback onShowContactInfoPressed;
   final VoidCallback onEditPressed;
   final VoidCallback onGenerateQRCodePressed;
+  final VoidCallback onChatPressed;
+
   final bool isGiven;
 
-  ItemBottomNavigationBar(
-      {required this.isOwner,
+  const ItemBottomNavigationBar(
+      {super.key,
+      required this.isOwner,
       required this.liked,
       required this.likes,
       required this.onLikePressed,
+      required this.onChatPressed,
       required this.onShowContactInfoPressed,
       required this.onEditPressed,
       required this.onGenerateQRCodePressed,
@@ -30,7 +34,7 @@ class ItemBottomNavigationBar extends StatelessWidget {
           if (isOwner)
             TextButton(
               onPressed: onEditPressed,
-              child: Text('Edit Listing'),
+              child: const Text('Edit Listing'),
             )
           else
             Row(
@@ -53,6 +57,11 @@ class ItemBottomNavigationBar extends StatelessWidget {
                     : onShowContactInfoPressed,
             child: Text(isOwner ? 'Generate QR Code' : 'Show Contact Info'),
           ),
+          if (!isOwner)
+            ElevatedButton(
+              onPressed: isGiven ? null : onChatPressed,
+              child: const Text('Chat'),
+            ),
         ],
       ),
     );

--- a/lib/MyHomePage.dart
+++ b/lib/MyHomePage.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:recloset/Components/BottomNavigationBar.dart';
 import 'package:recloset/Pages/QrCodeScanner.dart';
-import 'package:recloset/Pages/ChatRoom.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 import './Pages/Profile.dart';
 import './Pages/Home.dart';
 import './Pages/AddItem.dart';
+import 'Pages/ChatRoomList.dart';
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key, required this.title}) : super(key: key);
@@ -51,13 +52,23 @@ class _MyHomePageState extends State<MyHomePage> {
               ));
             },
           ),
-          IconButton(
-            icon: const Icon(Icons.chat_bubble),
-            tooltip: 'Open Chats',
-            onPressed: () {
-              Navigator.of(context).push(MaterialPageRoute(
-                builder: (context) => const ChatRoom(),
-              ));
+          StreamBuilder<User?>(
+            stream: FirebaseAuth.instance.authStateChanges(),
+            builder: (context, snapshot) {
+              if (snapshot.hasData) {
+                User user = snapshot.data!;
+                return IconButton(
+                  icon: const Icon(Icons.chat_bubble),
+                  tooltip: 'Open Chats',
+                  onPressed: () {
+                    Navigator.of(context).push(MaterialPageRoute(
+                      builder: (context) => const ChatRoomList(),
+                    ));
+                  },
+                );
+              } else {
+                return const SizedBox.shrink();
+              }
             },
           ),
         ],

--- a/lib/MyHomePage.dart
+++ b/lib/MyHomePage.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:recloset/Components/BottomNavigationBar.dart';
 import 'package:recloset/Pages/QrCodeScanner.dart';
+import 'package:recloset/Pages/ChatRoom.dart';
 
 import './Pages/Profile.dart';
 import './Pages/Home.dart';
 import './Pages/AddItem.dart';
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -15,17 +16,17 @@ class MyHomePage extends StatefulWidget {
 }
 
 TextStyle getOptionStyle() {
-  return TextStyle(fontSize: 30, fontWeight: FontWeight.bold);
+  return const TextStyle(fontSize: 30, fontWeight: FontWeight.bold);
 }
 
 class _MyHomePageState extends State<MyHomePage> {
   int _selectedIndex = 0;
 
   static final List<Widget> _widgetOptions = <Widget>[
-    Home(),
-    AddItem(),
+    const Home(),
+    const AddItem(),
     // QrCodeScanner(),
-    Profile(),
+    const Profile(),
   ];
 
   void _onItemTapped(int index) {
@@ -47,6 +48,15 @@ class _MyHomePageState extends State<MyHomePage> {
             onPressed: () {
               Navigator.of(context).push(MaterialPageRoute(
                 builder: (context) => const QrCodeScanner(),
+              ));
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.chat_bubble),
+            tooltip: 'Open Chats',
+            onPressed: () {
+              Navigator.of(context).push(MaterialPageRoute(
+                builder: (context) => const ChatRoom(),
               ));
             },
           ),

--- a/lib/Pages/AddItem.dart
+++ b/lib/Pages/AddItem.dart
@@ -7,7 +7,6 @@ import 'package:recloset/Components/AddPhotoCollection.dart';
 import 'package:recloset/Components/ChooseCategory.dart';
 import 'package:recloset/Components/ChooseCondition.dart';
 
-import '../Components/AddPhoto.dart';
 import '../Data/ListingProvider.dart';
 
 class AddItem extends StatefulWidget {

--- a/lib/Pages/ChatRoom.dart
+++ b/lib/Pages/ChatRoom.dart
@@ -1,31 +1,18 @@
-import 'dart:convert';
-import 'dart:io';
-import 'dart:math';
-
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:http/http.dart' as http;
-import 'package:image_picker/image_picker.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:provider/provider.dart';
-
-import '../app_state.dart';
-
-// For the testing purposes, you should probably use https://pub.dev/packages/uuid.
-String randomString() {
-  final random = Random.secure();
-  final values = List<int>.generate(16, (i) => random.nextInt(255));
-  return base64UrlEncode(values);
-}
+import 'package:uuid/uuid.dart';
 
 class ChatRoom extends StatefulWidget {
+  final String chat_id;
   final String item_id;
   final String current_id;
   final String other_id;
 
   const ChatRoom(
       {super.key,
+      required this.chat_id,
       required this.item_id,
       required this.current_id,
       required this.other_id});
@@ -37,12 +24,117 @@ class ChatRoom extends StatefulWidget {
 class _ChatRoomState extends State<ChatRoom> {
   final List<types.Message> _messages = [];
 
+  void initChat() {
+    final CollectionReference chatsCollection =
+        FirebaseFirestore.instance.collection('item_chats');
+    final CollectionReference messagesCollection =
+        FirebaseFirestore.instance.collection('messages');
+
+    // Check if the chat room already exists
+    chatsCollection
+        .doc(widget.chat_id)
+        .get()
+        .then((chatDoc) async {
+          print("Does it exist?");
+          print(widget.chat_id);
+          print(chatDoc.exists);
+
+          if (chatDoc.exists) {
+            // Chat room exists, proceed with fetching messages and setting up listeners
+
+            // Fetch existing messages for the chat room
+            messagesCollection
+                .where('chat_id', isEqualTo: widget.chat_id)
+                .orderBy('createdAt')
+                .snapshots()
+                .listen((QuerySnapshot snapshot) {
+              List<QueryDocumentSnapshot> documents = snapshot.docs;
+              // Process fetched messages and update your UI
+              // e.g., update a message list or chat bubble widget
+              for (var doc in documents) {
+                Map<String, dynamic> author = doc['author'];
+                String text = doc['text'];
+                int createdAt = doc['createdAt'];
+                print("listen: ");
+                print(doc);
+
+                final textMessage = types.TextMessage(
+                  author: types.User(id: author['id']),
+                  createdAt: createdAt,
+                  id: doc.id,
+                  text: text,
+                );
+                _addMessage(textMessage);
+              }
+            });
+          } else {
+            // Chat room does not exist, create it before initializing the chat
+
+            // Create the chat room document
+            await chatsCollection.doc(widget.chat_id).set({
+              'chat_id': widget.chat_id,
+              'item_id': widget.item_id,
+              'buyer_id': widget.chat_id.split('_')[1],
+              'seller_id': widget.chat_id.split('_')[1] != widget.current_id
+                  ? widget.current_id
+                  : widget.other_id,
+              // Add any other relevant properties for the chat room
+            }).then((_) {
+              // Chat room created, proceed with fetching messages and setting up listeners
+              // (similar to the code for an existing chat room)
+              // ...
+            }).catchError((error) {
+              // Error occurred while creating the chat room
+              print('Error creating chat room: $error');
+            });
+          }
+        })
+        .then((value) => {
+              // Listen for new messages in the chat room
+              messagesCollection
+                  .where('chat_id', isEqualTo: widget.chat_id)
+                  .orderBy('createdAt')
+                  .limitToLast(1)
+                  .snapshots()
+                  .listen((QuerySnapshot snapshot) {
+                List<QueryDocumentSnapshot> documents = snapshot.docs;
+                // Process new messages and update your UI
+                // e.g., append new messages to a message list or chat bubble widget
+                for (var doc in documents) {
+                  print("listen: ");
+                  print(doc);
+                  Map<String, dynamic> author = doc['author'];
+                  String text = doc['text'];
+                  int createdAt = doc['createdAt'];
+
+                  final textMessage = types.TextMessage(
+                    author: types.User(id: author['id']),
+                    createdAt: createdAt,
+                    id: doc.id,
+                    text: text,
+                  );
+                  _addMessage(textMessage);
+                }
+              })
+            })
+        .catchError((error) {
+          // Error occurred while checking if the chat room exists
+          print('Error checking chat room existence: $error');
+        });
+  }
+
+  @override
+  void initState() {
+    initChat();
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Chat(
         messages: _messages,
-        onAttachmentPressed: _handleImageSelection,
+        // onAttachmentPressed: _handleImageSelection,
         // onMessageTap: _handleMessageTap,
         onPreviewDataFetched: _handlePreviewDataFetched,
         onSendPressed: _handleSendPressed,
@@ -63,10 +155,13 @@ class _ChatRoomState extends State<ChatRoom> {
   }
 
   void _addMessage(types.Message message) {
-    print(message);
-    setState(() {
-      _messages.insert(0, message);
-    });
+    // avoid adding duplicated messages
+    final index = _messages.indexWhere((element) => element.id == message.id);
+    if (index == -1) {
+      setState(() {
+        _messages.insert(0, message);
+      });
+    }
   }
 
   // void _handleAttachmentPressed() {
@@ -131,76 +226,76 @@ class _ChatRoomState extends State<ChatRoom> {
     // }
   }
 
-  void _handleImageSelection() async {
-    final result = await ImagePicker().pickImage(
-      imageQuality: 70,
-      maxWidth: 1440,
-      source: ImageSource.gallery,
-    );
+  // void _handleImageSelection() async {
+  //   final result = await ImagePicker().pickImage(
+  //     imageQuality: 70,
+  //     maxWidth: 1440,
+  //     source: ImageSource.gallery,
+  //   );
 
-    if (result != null) {
-      final bytes = await result.readAsBytes();
-      final image = await decodeImageFromList(bytes);
+  //   if (result != null) {
+  //     final bytes = await result.readAsBytes();
+  //     final image = await decodeImageFromList(bytes);
 
-      final message = types.ImageMessage(
-        author: types.User(id: widget.current_id),
-        createdAt: DateTime.now().millisecondsSinceEpoch,
-        height: image.height.toDouble(),
-        id: randomString(),
-        name: result.name,
-        size: bytes.length,
-        uri: result.path,
-        width: image.width.toDouble(),
-      );
+  //     final message = types.ImageMessage(
+  //       author: types.User(id: widget.current_id),
+  //       createdAt: DateTime.now().millisecondsSinceEpoch,
+  //       height: image.height.toDouble(),
+  //       id: randomString(),
+  //       name: result.name,
+  //       size: bytes.length,
+  //       uri: result.path,
+  //       width: image.width.toDouble(),
+  //     );
 
-      _addMessage(message);
-    }
-  }
+  //     _addMessage(message);
+  //   }
+  // }
 
-  void _handleMessageTap(BuildContext _, types.Message message) async {
-    if (message is types.FileMessage) {
-      var localPath = message.uri;
+  // void _handleMessageTap(BuildContext _, types.Message message) async {
+  //   if (message is types.FileMessage) {
+  //     var localPath = message.uri;
 
-      if (message.uri.startsWith('http')) {
-        try {
-          final index =
-              _messages.indexWhere((element) => element.id == message.id);
-          final updatedMessage =
-              (_messages[index] as types.FileMessage).copyWith(
-            isLoading: true,
-          );
+  //     if (message.uri.startsWith('http')) {
+  //       try {
+  //         final index =
+  //             _messages.indexWhere((element) => element.id == message.id);
+  //         final updatedMessage =
+  //             (_messages[index] as types.FileMessage).copyWith(
+  //           isLoading: true,
+  //         );
 
-          setState(() {
-            _messages[index] = updatedMessage;
-          });
+  //         setState(() {
+  //           _messages[index] = updatedMessage;
+  //         });
 
-          final client = http.Client();
-          final request = await client.get(Uri.parse(message.uri));
-          final bytes = request.bodyBytes;
-          final documentsDir = (await getApplicationDocumentsDirectory()).path;
-          localPath = '$documentsDir/${message.name}';
+  //         final client = http.Client();
+  //         final request = await client.get(Uri.parse(message.uri));
+  //         final bytes = request.bodyBytes;
+  //         final documentsDir = (await getApplicationDocumentsDirectory()).path;
+  //         localPath = '$documentsDir/${message.name}';
 
-          if (!File(localPath).existsSync()) {
-            final file = File(localPath);
-            await file.writeAsBytes(bytes);
-          }
-        } finally {
-          final index =
-              _messages.indexWhere((element) => element.id == message.id);
-          final updatedMessage =
-              (_messages[index] as types.FileMessage).copyWith(
-            isLoading: null,
-          );
+  //         if (!File(localPath).existsSync()) {
+  //           final file = File(localPath);
+  //           await file.writeAsBytes(bytes);
+  //         }
+  //       } finally {
+  //         final index =
+  //             _messages.indexWhere((element) => element.id == message.id);
+  //         final updatedMessage =
+  //             (_messages[index] as types.FileMessage).copyWith(
+  //           isLoading: null,
+  //         );
 
-          setState(() {
-            _messages[index] = updatedMessage;
-          });
-        }
-      }
+  //         setState(() {
+  //           _messages[index] = updatedMessage;
+  //         });
+  //       }
+  //     }
 
-      // await OpenFilex.open(localPath);
-    }
-  }
+  //     // await OpenFilex.open(localPath);
+  //   }
+  // }
 
   void _handlePreviewDataFetched(
     types.TextMessage message,
@@ -217,13 +312,33 @@ class _ChatRoomState extends State<ChatRoom> {
   }
 
   void _handleSendPressed(types.PartialText message) {
-    final textMessage = types.TextMessage(
+    const uuid = Uuid();
+    final timeNow = DateTime.now().millisecondsSinceEpoch;
+
+    final types.TextMessage textMessage = types.TextMessage(
       author: types.User(id: widget.current_id),
-      createdAt: DateTime.now().millisecondsSinceEpoch,
-      id: randomString(),
+      createdAt: timeNow,
+      id: uuid.v4(), // Generate a unique identifier using UUID
       text: message.text,
     );
 
-    _addMessage(textMessage);
+    // Save the text message to the Firestore collection
+    FirebaseFirestore.instance.collection('messages').doc(textMessage.id).set({
+      ...textMessage.toJson(),
+      'chat_id': widget.chat_id,
+    }).then((_) {
+      FirebaseFirestore.instance
+          .collection('item_chats')
+          .doc(widget.chat_id)
+          .update({
+        'last_updated': timeNow,
+        'last_message': message.text,
+      });
+    }).catchError((error) {
+      // Error occurred while sending the message
+      print('Error sending message: $error');
+    });
+
+    // _addMessage(textMessage);
   }
 }

--- a/lib/Pages/ChatRoom.dart
+++ b/lib/Pages/ChatRoom.dart
@@ -8,6 +8,9 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:provider/provider.dart';
+
+import '../app_state.dart';
 
 // For the testing purposes, you should probably use https://pub.dev/packages/uuid.
 String randomString() {
@@ -17,7 +20,15 @@ String randomString() {
 }
 
 class ChatRoom extends StatefulWidget {
-  const ChatRoom({super.key});
+  final String item_id;
+  final String current_id;
+  final String other_id;
+
+  const ChatRoom(
+      {super.key,
+      required this.item_id,
+      required this.current_id,
+      required this.other_id});
 
   @override
   State<ChatRoom> createState() => _ChatRoomState();
@@ -25,33 +36,31 @@ class ChatRoom extends StatefulWidget {
 
 class _ChatRoomState extends State<ChatRoom> {
   final List<types.Message> _messages = [];
-  final _user = const types.User(
-      id: '82091008-a484-4a89-ae75-a22bf8d6f3ac',
-      firstName: "User1",
-      imageUrl: 'https://api.dicebear.com/6.x/adventurer/svg?seed=Pumpkiaaa');
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-        body: Chat(
-          messages: _messages,
-          onAttachmentPressed: _handleImageSelection,
-          // onMessageTap: _handleMessageTap,
-          onPreviewDataFetched: _handlePreviewDataFetched,
-          onSendPressed: _handleSendPressed,
-          user: _user,
-          theme: const DefaultChatTheme(
-            inputBackgroundColor: Colors.grey,
-            primaryColor: Colors.green,
-          ),
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Chat(
+        messages: _messages,
+        onAttachmentPressed: _handleImageSelection,
+        // onMessageTap: _handleMessageTap,
+        onPreviewDataFetched: _handlePreviewDataFetched,
+        onSendPressed: _handleSendPressed,
+        user: types.User(id: widget.current_id),
+        theme: const DefaultChatTheme(
+          inputBackgroundColor: Colors.grey,
+          primaryColor: Colors.green,
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-          child: const Icon(Icons.arrow_back),
-        ),
-        floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
-      );
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).pop();
+        },
+        child: const Icon(Icons.arrow_back),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
+    );
+  }
 
   void _addMessage(types.Message message) {
     print(message);
@@ -134,7 +143,7 @@ class _ChatRoomState extends State<ChatRoom> {
       final image = await decodeImageFromList(bytes);
 
       final message = types.ImageMessage(
-        author: _user,
+        author: types.User(id: widget.current_id),
         createdAt: DateTime.now().millisecondsSinceEpoch,
         height: image.height.toDouble(),
         id: randomString(),
@@ -207,23 +216,9 @@ class _ChatRoomState extends State<ChatRoom> {
     });
   }
 
-  types.User randomUser() {
-    Random random = Random();
-    bool shouldAppendOther = random.nextBool();
-
-    if (shouldAppendOther) {
-      return const types.User(
-          id: '82091008-a484-4a89-ae75-a22bf8d6f3ac-other',
-          firstName: "User2",
-          imageUrl: 'https://api.dicebear.com/6.x/adventurer/svg?seed=Pumpkin');
-    } else {
-      return _user;
-    }
-  }
-
   void _handleSendPressed(types.PartialText message) {
     final textMessage = types.TextMessage(
-      author: randomUser(),
+      author: types.User(id: widget.current_id),
       createdAt: DateTime.now().millisecondsSinceEpoch,
       id: randomString(),
       text: message.text,

--- a/lib/Pages/ChatRoom.dart
+++ b/lib/Pages/ChatRoom.dart
@@ -1,0 +1,234 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+
+// For the testing purposes, you should probably use https://pub.dev/packages/uuid.
+String randomString() {
+  final random = Random.secure();
+  final values = List<int>.generate(16, (i) => random.nextInt(255));
+  return base64UrlEncode(values);
+}
+
+class ChatRoom extends StatefulWidget {
+  const ChatRoom({super.key});
+
+  @override
+  State<ChatRoom> createState() => _ChatRoomState();
+}
+
+class _ChatRoomState extends State<ChatRoom> {
+  final List<types.Message> _messages = [];
+  final _user = const types.User(
+      id: '82091008-a484-4a89-ae75-a22bf8d6f3ac',
+      firstName: "User1",
+      imageUrl: 'https://api.dicebear.com/6.x/adventurer/svg?seed=Pumpkiaaa');
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: Chat(
+          messages: _messages,
+          onAttachmentPressed: _handleImageSelection,
+          // onMessageTap: _handleMessageTap,
+          onPreviewDataFetched: _handlePreviewDataFetched,
+          onSendPressed: _handleSendPressed,
+          user: _user,
+          theme: const DefaultChatTheme(
+            inputBackgroundColor: Colors.grey,
+            primaryColor: Colors.green,
+          ),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Icon(Icons.arrow_back),
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
+      );
+
+  void _addMessage(types.Message message) {
+    print(message);
+    setState(() {
+      _messages.insert(0, message);
+    });
+  }
+
+  // void _handleAttachmentPressed() {
+  //   showModalBottomSheet<void>(
+  //     context: context,
+  //     builder: (BuildContext context) => SafeArea(
+  //       child: SizedBox(
+  //         height: 144,
+  //         child: Column(
+  //           crossAxisAlignment: CrossAxisAlignment.stretch,
+  //           children: <Widget>[
+  //             TextButton(
+  //               onPressed: () {
+  //                 Navigator.pop(context);
+  //                 _handleImageSelection();
+  //               },
+  //               child: const Align(
+  //                 alignment: AlignmentDirectional.centerStart,
+  //                 child: Text('Photo'),
+  //               ),
+  //             ),
+  //             TextButton(
+  //               onPressed: () {
+  //                 Navigator.pop(context);
+  //                 _handleFileSelection();
+  //               },
+  //               child: const Align(
+  //                 alignment: AlignmentDirectional.centerStart,
+  //                 child: Text('File'),
+  //               ),
+  //             ),
+  //             TextButton(
+  //               onPressed: () => Navigator.pop(context),
+  //               child: const Align(
+  //                 alignment: AlignmentDirectional.centerStart,
+  //                 child: Text('Cancel'),
+  //               ),
+  //             ),
+  //           ],
+  //         ),
+  //       ),
+  //     ),
+  //   );
+  // }
+
+  void _handleFileSelection() async {
+    // final result = await FilePicker.platform.pickFiles(
+    //   type: FileType.any,
+    // );
+
+    // if (result != null && result.files.single.path != null) {
+    //   final message = types.FileMessage(
+    //     author: _user,
+    //     createdAt: DateTime.now().millisecondsSinceEpoch,
+    //     id: randomString(),
+    //     name: result.files.single.name,
+    //     size: result.files.single.size,
+    //     uri: result.files.single.path!,
+    //   );
+
+    //   _addMessage(message);
+    // }
+  }
+
+  void _handleImageSelection() async {
+    final result = await ImagePicker().pickImage(
+      imageQuality: 70,
+      maxWidth: 1440,
+      source: ImageSource.gallery,
+    );
+
+    if (result != null) {
+      final bytes = await result.readAsBytes();
+      final image = await decodeImageFromList(bytes);
+
+      final message = types.ImageMessage(
+        author: _user,
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+        height: image.height.toDouble(),
+        id: randomString(),
+        name: result.name,
+        size: bytes.length,
+        uri: result.path,
+        width: image.width.toDouble(),
+      );
+
+      _addMessage(message);
+    }
+  }
+
+  void _handleMessageTap(BuildContext _, types.Message message) async {
+    if (message is types.FileMessage) {
+      var localPath = message.uri;
+
+      if (message.uri.startsWith('http')) {
+        try {
+          final index =
+              _messages.indexWhere((element) => element.id == message.id);
+          final updatedMessage =
+              (_messages[index] as types.FileMessage).copyWith(
+            isLoading: true,
+          );
+
+          setState(() {
+            _messages[index] = updatedMessage;
+          });
+
+          final client = http.Client();
+          final request = await client.get(Uri.parse(message.uri));
+          final bytes = request.bodyBytes;
+          final documentsDir = (await getApplicationDocumentsDirectory()).path;
+          localPath = '$documentsDir/${message.name}';
+
+          if (!File(localPath).existsSync()) {
+            final file = File(localPath);
+            await file.writeAsBytes(bytes);
+          }
+        } finally {
+          final index =
+              _messages.indexWhere((element) => element.id == message.id);
+          final updatedMessage =
+              (_messages[index] as types.FileMessage).copyWith(
+            isLoading: null,
+          );
+
+          setState(() {
+            _messages[index] = updatedMessage;
+          });
+        }
+      }
+
+      // await OpenFilex.open(localPath);
+    }
+  }
+
+  void _handlePreviewDataFetched(
+    types.TextMessage message,
+    types.PreviewData previewData,
+  ) {
+    final index = _messages.indexWhere((element) => element.id == message.id);
+    final updatedMessage = (_messages[index] as types.TextMessage).copyWith(
+      previewData: previewData,
+    );
+
+    setState(() {
+      _messages[index] = updatedMessage;
+    });
+  }
+
+  types.User randomUser() {
+    Random random = Random();
+    bool shouldAppendOther = random.nextBool();
+
+    if (shouldAppendOther) {
+      return const types.User(
+          id: '82091008-a484-4a89-ae75-a22bf8d6f3ac-other',
+          firstName: "User2",
+          imageUrl: 'https://api.dicebear.com/6.x/adventurer/svg?seed=Pumpkin');
+    } else {
+      return _user;
+    }
+  }
+
+  void _handleSendPressed(types.PartialText message) {
+    final textMessage = types.TextMessage(
+      author: randomUser(),
+      createdAt: DateTime.now().millisecondsSinceEpoch,
+      id: randomString(),
+      text: message.text,
+    );
+
+    _addMessage(textMessage);
+  }
+}

--- a/lib/Pages/ChatRoomList.dart
+++ b/lib/Pages/ChatRoomList.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:intl/intl.dart';
+
+import 'ChatRoom.dart';
+
+Future<List<DocumentSnapshot>> fetchChats() async {
+  String currentUserId = FirebaseAuth.instance.currentUser!.uid;
+  print(currentUserId);
+  QuerySnapshot querySnapshot = await FirebaseFirestore.instance
+      .collection('item_chats')
+      .where('seller_id', isEqualTo: currentUserId)
+      .orderBy('last_updated', descending: true)
+      .get();
+
+  List<DocumentSnapshot> sellerChats = querySnapshot.docs;
+
+  querySnapshot = await FirebaseFirestore.instance
+      .collection('item_chats')
+      .where('buyer_id', isEqualTo: currentUserId)
+      .orderBy('last_updated', descending: true)
+      .get();
+
+  List<DocumentSnapshot> buyerChats = querySnapshot.docs;
+
+  List<DocumentSnapshot> allChats = [...sellerChats, ...buyerChats];
+  allChats.sort((a, b) => b['last_updated'].compareTo(a['last_updated']));
+  print("all chats:");
+
+  print(allChats);
+  return allChats;
+}
+
+class ChatRoomList extends StatelessWidget {
+  const ChatRoomList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat List'),
+      ),
+      body: FutureBuilder<List<DocumentSnapshot>>(
+        future: fetchChats(),
+        builder: (BuildContext context,
+            AsyncSnapshot<List<DocumentSnapshot>> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          } else if (snapshot.hasError) {
+            return const Center(
+              child: Text('Error loading chats.'),
+            );
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(
+              child: Text('No chats available.'),
+            );
+          } else {
+            List<DocumentSnapshot> chats = snapshot.data!;
+
+            return ListView.builder(
+              itemCount: chats.length,
+              itemBuilder: (BuildContext context, int index) {
+                DocumentSnapshot chat = chats[index];
+                String chatId = chat.id;
+
+                String otherUserId =
+                    chat['seller_id'] == FirebaseAuth.instance.currentUser!.uid
+                        ? chat['buyer_id']
+                        : chat['seller_id'];
+                String itemId = chatId.split('_')[0];
+
+                return Column(
+                  children: [
+                    ListTile(
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => ChatRoom(
+                              chat_id: chatId,
+                              item_id: itemId,
+                              other_id: otherUserId,
+                              current_id:
+                                  FirebaseAuth.instance.currentUser!.uid,
+                            ),
+                          ),
+                        );
+                      },
+                      leading: CircleAvatar(
+                        backgroundImage: NetworkImage(
+                          'https://api.dicebear.com/6.x/fun-emoji/png?seed=$otherUserId',
+                        ),
+                      ),
+                      title: FutureBuilder<DocumentSnapshot>(
+                        future: FirebaseFirestore.instance
+                            .collection('items')
+                            .doc(itemId)
+                            .get(),
+                        builder: (BuildContext context,
+                            AsyncSnapshot<DocumentSnapshot> snapshot) {
+                          if (snapshot.connectionState ==
+                              ConnectionState.waiting) {
+                            return const CircularProgressIndicator();
+                          } else if (snapshot.hasError || !snapshot.hasData) {
+                            return const Text('Could not fetch item name');
+                          } else {
+                            String itemTitle = snapshot.data!['title'];
+                            return Text(itemTitle);
+                          }
+                        },
+                      ),
+                      subtitle: Text('${chat['last_message']}'),
+                      trailing: FutureBuilder<DocumentSnapshot>(
+                        future: FirebaseFirestore.instance
+                            .collection('items')
+                            .doc(itemId)
+                            .get(),
+                        builder: (BuildContext context,
+                            AsyncSnapshot<DocumentSnapshot> snapshot) {
+                          if (snapshot.connectionState ==
+                              ConnectionState.waiting) {
+                            return const CircularProgressIndicator();
+                          } else if (snapshot.hasError) {
+                            return const Icon(Icons.error);
+                          } else if (!snapshot.hasData) {
+                            return const Icon(Icons.image);
+                          } else {
+                            String itemImage = snapshot.data!['images'][0];
+
+                            DateTime lastMessageTime =
+                                DateTime.fromMillisecondsSinceEpoch(
+                              chat['last_updated'] as int,
+                            );
+                            String formattedTime = DateFormat('dd/MM/yyy HH:mm')
+                                .format(lastMessageTime);
+
+                            return Column(
+                              children: [
+                                CircleAvatar(
+                                  backgroundImage: NetworkImage(itemImage),
+                                ),
+                                const SizedBox(height: 2),
+                                Text(
+                                  formattedTime,
+                                  style: const TextStyle(
+                                      fontSize: 12, color: Colors.grey),
+                                ),
+                              ],
+                            );
+                          }
+                        },
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                          vertical: 8, horizontal: 16),
+                    ),
+                    const Divider(
+                      color: Colors.grey,
+                      height: 1,
+                      thickness: 1,
+                      indent: 16,
+                      endIndent: 16,
+                    ),
+                  ],
+                );
+              },
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/Pages/Profile.dart
+++ b/lib/Pages/Profile.dart
@@ -68,8 +68,9 @@ class _ProfilePageState extends State<Profile>
               const ProfilePageHeader(),
               Positioned(
                   top: 100,
-                  child:
-                      ProfilePicture(imagePath: appState.user?.photoURL ?? ""))
+                  child: ProfilePicture(
+                      imagePath:
+                          'https://api.dicebear.com/6.x/fun-emoji/png?seed=${Provider.of<ApplicationState>(context, listen: false).user?.uid}'))
             ],
           ),
           Container(
@@ -117,8 +118,12 @@ class _ProfilePageState extends State<Profile>
                 child: TabBarView(
                   controller: _tabController,
                   children: [
-                    Center(child: ProfilePageItemList(ids: appState.userState?.listedItems ?? [])),
-                    Center(child: ProfilePageItemList(ids: appState.userState?.likes ?? [])),
+                    Center(
+                        child: ProfilePageItemList(
+                            ids: appState.userState?.listedItems ?? [])),
+                    Center(
+                        child: ProfilePageItemList(
+                            ids: appState.userState?.likes ?? [])),
                     Column(
                         mainAxisAlignment: MainAxisAlignment.start,
                         children: const [

--- a/lib/Pages/ViewItem.dart
+++ b/lib/Pages/ViewItem.dart
@@ -1,7 +1,9 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:recloset/Components/Carousel.dart';
 import 'package:flutter/services.dart';
 import 'package:recloset/Components/ContactDialog.dart';
+import 'package:recloset/Pages/ChatRoom.dart';
 import 'package:recloset/Pages/QrCodeGen.dart';
 import 'package:provider/provider.dart';
 import 'package:recloset/Services/ItemService.dart';
@@ -23,7 +25,7 @@ final List<String> imgList = [
 class ViewItem extends StatefulWidget {
   final String id;
 
-  const ViewItem({Key? key, required this.id});
+  const ViewItem({super.key, required this.id});
 
   @override
   State<StatefulWidget> createState() => _ViewItemState();
@@ -45,6 +47,7 @@ class _ViewItemState extends State<ViewItem> {
   String owner = "";
   String email = "";
   String size = "";
+  String current_user = "";
 
   @override
   void initState() {
@@ -76,6 +79,7 @@ class _ViewItemState extends State<ViewItem> {
       owner = item.owner;
       email = user?.email ?? "";
       size = item.size;
+      current_user = FirebaseAuth.instance.currentUser!.uid;
     });
   }
 
@@ -83,14 +87,14 @@ class _ViewItemState extends State<ViewItem> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: ListView(shrinkWrap: true, children: [
-        Container(
+        SizedBox(
             height: MediaQuery.of(context).size.height * 0.3,
             child: Carousel(imageUrls: imageUrls)),
         Container(
-          padding: EdgeInsets.only(left: 10.0),
+          padding: const EdgeInsets.only(left: 10.0),
           child: Text(
-            '$name',
-            style: TextStyle(
+            name,
+            style: const TextStyle(
               fontSize: 24,
               fontWeight: FontWeight.bold,
             ),
@@ -98,129 +102,129 @@ class _ViewItemState extends State<ViewItem> {
           ),
         ),
         Container(
-            padding: EdgeInsets.all(20),
+            padding: const EdgeInsets.all(20),
             child: Column(
               children: [
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.calendar_today,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
+                    const SizedBox(width: 10),
                     Text('Posted on ${date.day}/${date.month}/${date.year}'),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.monetization_on,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
+                    const SizedBox(width: 10),
                     Text('$credits'),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.favorite,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
+                    const SizedBox(width: 10),
                     Text(likes.length.toString()),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.info,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$status'),
+                    const SizedBox(width: 10),
+                    Text(status),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.category,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$category'),
+                    const SizedBox(width: 10),
+                    Text(category),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.check_circle,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$condition'),
+                    const SizedBox(width: 10),
+                    Text(condition),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.person,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$target'),
+                    const SizedBox(width: 10),
+                    Text(target),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.straighten,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$size'),
+                    const SizedBox(width: 10),
+                    Text(size),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.location_on,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$location'),
+                    const SizedBox(width: 10),
+                    Text(location),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.handshake,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
-                    Text('$dealOptions'),
+                    const SizedBox(width: 10),
+                    Text(dealOptions),
                   ],
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.description,
                       color: Colors.grey,
                     ),
-                    SizedBox(width: 10),
+                    const SizedBox(width: 10),
                     Flexible(
                       child: Text(
-                        '$description',
+                        description,
                         maxLines: 100,
                         overflow: TextOverflow
                             .ellipsis, // Change to the type of overflow you want
@@ -268,6 +272,16 @@ class _ViewItemState extends State<ViewItem> {
               },
             );
           },
+          onChatPressed: () {
+            Navigator.of(context).push(MaterialPageRoute(
+              builder: (context) => ChatRoom(
+                chat_id: '${widget.id}_$current_user',
+                item_id: widget.id,
+                other_id: owner,
+                current_id: current_user,
+              ),
+            ));
+          },
           onEditPressed: () => {},
           onGenerateQRCodePressed: () {
             Navigator.of(context).push(MaterialPageRoute(
@@ -306,3 +320,5 @@ class _ViewItemState extends State<ViewItem> {
     super.dispose();
   }
 }
+
+class ChatScreen {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,12 +44,14 @@ dependencies:
   firebase_ui_auth: ^1.1.16
   firebase_ui_oauth_google: ^1.0.21
   provider: ^6.0.5
-  image_picker: ^0.8.7
+  image_picker: ^0.8.7+5
   firebase_storage: ^11.0.16
   qr_flutter: ^4.0.0
   share_plus: ^6.3.1
   screenshot: ^1.3.0
   url_launcher: ^6.1.10
+  flutter_chat_ui: ^1.6.6
+  flutter_link_previewer: ^3.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Changes:
* Added viewing of chat list from app bar
* Added navigating to chat via chat list or via an item page
* Added transactions for chats, you can now create offers and accept offers via a chat
* Updated icons to use dicebear's icons for privacy reasons in both Chat and Profile page

### Screenshots:

Chat list:
![image](https://github.com/reCloset/reCloset/assets/50147457/10817067-c429-4f38-a8f9-8279ce07b412)

Chat room - buyer is able to intiate offer
![image](https://github.com/reCloset/reCloset/assets/50147457/4057d951-cae3-474b-9963-6e1644da7cf8)


Chat room - seller/owner is able to accept offer once an offer is given (otherwise no accept button will appear)
![image](https://github.com/reCloset/reCloset/assets/50147457/2344e316-010c-41ff-9027-246a909b4e40)
